### PR TITLE
Exercise 5 - Collateralized Vault

### DIFF
--- a/contracts/Dai.sol
+++ b/contracts/Dai.sol
@@ -1,0 +1,218 @@
+/**
+ *Submitted for verification at Etherscan.io on 2019-11-14
+ */
+
+// hevm: flattened sources of /nix/store/8xb41r4qd0cjb63wcrxf1qmfg88p0961-dss-6fd7de0/src/dai.sol
+pragma solidity >=0.8.4;
+
+////// /nix/store/8xb41r4qd0cjb63wcrxf1qmfg88p0961-dss-6fd7de0/src/lib.sol
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+/* pragma solidity 0.5.12; */
+
+// contract LibNote {
+//     event LogNote(
+//         bytes4   indexed  sig,
+//         address  indexed  usr,
+//         bytes32  indexed  arg1,
+//         bytes32  indexed  arg2,
+//         bytes             data
+//     ) anonymous;
+
+//     modifier note {
+//         _;
+//         assembly {
+//             // log an 'anonymous' event with a constant 6 words of calldata
+//             // and four indexed topics: selector, caller, arg1 and arg2
+//             let mark := msize()                         // end of memory ensures zero
+//             mstore(0x40, add(mark, 288))              // update free memory pointer
+//             mstore(mark, 0x20)                        // bytes type data offset
+//             mstore(add(mark, 0x20), 224)              // bytes size (padded)
+//             calldatacopy(add(mark, 0x40), 0, 224)     // bytes payload
+//             log4(mark, 288,                           // calldata
+//                  shl(224, shr(224, calldataload(0))), // msg.sig
+//                  caller(),                              // msg.sender
+//                  calldataload(4),                     // arg1
+//                  calldataload(36)                     // arg2
+//                 )
+//         }
+//     }
+// }
+
+////// /nix/store/8xb41r4qd0cjb63wcrxf1qmfg88p0961-dss-6fd7de0/src/dai.sol
+// Copyright (C) 2017, 2018, 2019 dbrock, rain, mrchico
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+/* pragma solidity 0.5.12; */
+
+/* import "./lib.sol"; */
+
+contract Dai {
+    // --- Auth ---
+    mapping(address => uint256) public wards;
+
+    function rely(address guy) external auth {
+        wards[guy] = 1;
+    }
+
+    function deny(address guy) external auth {
+        wards[guy] = 0;
+    }
+
+    modifier auth() {
+        require(wards[msg.sender] == 1, "Dai/not-authorized");
+        _;
+    }
+
+    // --- ERC20 Data ---
+    string public constant name = "Dai Stablecoin";
+    string public constant symbol = "DAI";
+    string public constant version = "1";
+    uint8 public constant decimals = 18;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+    mapping(address => uint256) public nonces;
+
+    event Approval(address indexed src, address indexed guy, uint256 wad);
+    event Transfer(address indexed src, address indexed dst, uint256 wad);
+
+    // --- Math ---
+    function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require((z = x + y) >= x);
+    }
+
+    function sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require((z = x - y) <= x);
+    }
+
+    // --- EIP712 niceties ---
+    bytes32 public DOMAIN_SEPARATOR;
+    // bytes32 public constant PERMIT_TYPEHASH = keccak256("Permit(address holder,address spender,uint256 nonce,uint256 expiry,bool allowed)");
+    bytes32 public constant PERMIT_TYPEHASH = 0xea2aa0a1be11a07ed86d755c93467f4f82362b452371d1ba94d1715123511acb;
+
+    constructor(uint256 chainId_) {
+        wards[msg.sender] = 1;
+        DOMAIN_SEPARATOR = keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256(bytes(name)),
+                keccak256(bytes(version)),
+                chainId_,
+                address(this)
+            )
+        );
+    }
+
+    // --- Token ---
+    function transfer(address dst, uint256 wad) external returns (bool) {
+        return transferFrom(msg.sender, dst, wad);
+    }
+
+    function transferFrom(
+        address src,
+        address dst,
+        uint256 wad
+    ) public returns (bool) {
+        require(balanceOf[src] >= wad, "Dai/insufficient-balance");
+        if (src != msg.sender && allowance[src][msg.sender] != uint256(256)) {
+            require(allowance[src][msg.sender] >= wad, "Dai/insufficient-allowance");
+            allowance[src][msg.sender] = sub(allowance[src][msg.sender], wad);
+        }
+        balanceOf[src] = sub(balanceOf[src], wad);
+        balanceOf[dst] = add(balanceOf[dst], wad);
+        emit Transfer(src, dst, wad);
+        return true;
+    }
+
+    function mint(address usr, uint256 wad) external auth {
+        balanceOf[usr] = add(balanceOf[usr], wad);
+        totalSupply = add(totalSupply, wad);
+        emit Transfer(address(0), usr, wad);
+    }
+
+    function burn(address usr, uint256 wad) external {
+        require(balanceOf[usr] >= wad, "Dai/insufficient-balance");
+        if (usr != msg.sender && allowance[usr][msg.sender] != uint256(256)) {
+            require(allowance[usr][msg.sender] >= wad, "Dai/insufficient-allowance");
+            allowance[usr][msg.sender] = sub(allowance[usr][msg.sender], wad);
+        }
+        balanceOf[usr] = sub(balanceOf[usr], wad);
+        totalSupply = sub(totalSupply, wad);
+        emit Transfer(usr, address(0), wad);
+    }
+
+    function approve(address usr, uint256 wad) external returns (bool) {
+        allowance[msg.sender][usr] = wad;
+        emit Approval(msg.sender, usr, wad);
+        return true;
+    }
+
+    // --- Alias ---
+    function push(address usr, uint256 wad) external {
+        transferFrom(msg.sender, usr, wad);
+    }
+
+    function pull(address usr, uint256 wad) external {
+        transferFrom(usr, msg.sender, wad);
+    }
+
+    function move(
+        address src,
+        address dst,
+        uint256 wad
+    ) external {
+        transferFrom(src, dst, wad);
+    }
+
+    // --- Approve by signature ---
+    function permit(
+        address holder,
+        address spender,
+        uint256 nonce,
+        uint256 expiry,
+        bool allowed,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                DOMAIN_SEPARATOR,
+                keccak256(abi.encode(PERMIT_TYPEHASH, holder, spender, nonce, expiry, allowed))
+            )
+        );
+
+        require(holder != address(0), "Dai/invalid-address-0");
+        require(holder == ecrecover(digest, v, r, s), "Dai/invalid-permit");
+        require(nonce == nonces[holder]++, "Dai/invalid-nonce");
+        uint256 wad = allowed ? uint256(256) : 0;
+        allowance[holder][spender] = wad;
+        emit Approval(holder, spender, wad);
+    }
+}

--- a/contracts/MockPriceFeedAggregator.sol
+++ b/contracts/MockPriceFeedAggregator.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.4;
+
+import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+
+contract MockPriceFeedAggregator is AggregatorV3Interface {
+    int256 public rate; // settable rate that will be returned
+
+    constructor(int256 _rate) {
+        rate = _rate;
+    }
+
+    function setRate(int256 _rate) external {
+        rate = _rate;
+    }
+
+    function decimals() external pure override returns (uint8) {
+        return 18;
+    }
+
+    function description() external pure override returns (string memory) {
+        return "Mock Price Feed Aggregtator";
+    }
+
+    function version() external pure override returns (uint256) {
+        return 1;
+    }
+
+    // getRoundData and latestRoundData should both raise "No data present"
+    // if they do not have data to report, instead of returning unset values
+    // which could be misinterpreted as actual reported values.
+    function getRoundData(uint80 _roundId)
+        external
+        pure
+        override
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        )
+    {
+        return (_roundId, 1, 1, 1, 1);
+    }
+
+    function latestRoundData()
+        external
+        view
+        override
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        )
+    {
+        return (1, rate, 1, 1, 1);
+    }
+}

--- a/contracts/Vault4.sol
+++ b/contracts/Vault4.sol
@@ -4,16 +4,16 @@ pragma solidity >=0.8.4;
 import "./Dai.sol";
 import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 
-// @title  Collateralized Vault
-// @notice Deposit Eth - Borrow Dai - Repay Dai - Withdraw Eth
+// @title  Collateralized Vault - An exercise for the Yield Mentorship program
+// @notice Deposit Eth - Borrow Dai - Repay Dai - Withdraw Eth -- Liquidate
 contract Vault4 {
     Dai public token;
     AggregatorV3Interface internal priceFeed;
 
     address public owner;
 
-    mapping(address => uint256) public deposits; // Stored in eth
-    mapping(address => uint256) public loans; // Stored in dai
+    mapping(address => uint256) public deposits; // Amounts in eth
+    mapping(address => uint256) public loans; // Amounts in dai
 
     //@notice The eth/dai exchange rate from oracle
     uint256 public exchangeRate;
@@ -24,16 +24,15 @@ contract Vault4 {
     event Repay(uint256 wad);
     event Liquidate(address guy, uint256 loanDaiAmt, uint256 depositEthAmt);
 
-    // @dev Deploy with address of Dai Stablecoin token
+    // @dev Deploy with addresses of Dai Stablecoin token and Chainlink Price Feed aggregator
     constructor(Dai _token, address _oracleAddress) {
         token = _token;
         owner = msg.sender;
         priceFeed = AggregatorV3Interface(_oracleAddress);
     }
 
-    //@notice Function used to get dai/eth exchange from price feed and convert eth to dai
-    //@param wad amount to apply exchange rate to
-    //@param update If true, will fetch exchange rate from oracle
+    //@notice Function used to get latest dai/eth exchange from price feed and convert eth to dai
+    //@param _ethValue amount to apply exchange rate to
     function applyExchangeRate(uint256 _ethValue) internal view returns (uint256 _resultDai) {
         (, int256 answer, , , ) = priceFeed.latestRoundData();
         require(answer > 0, "Amount > 0 required");

--- a/contracts/Vault4.sol
+++ b/contracts/Vault4.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.4;
+
+import "./Dai.sol";
+import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+
+// @title  Collateralized Vault
+// @notice Deposit Eth - Borrow Dai - Repay Dai - Withdraw Eth
+contract Vault4 {
+    Dai public token;
+    AggregatorV3Interface internal priceFeed;
+
+    address public owner;
+
+    mapping(address => uint256) public deposits; // Stored in eth
+    mapping(address => uint256) public loans; // Stored in dai
+
+    //@notice The eth/dai exchange rate from oracle
+    uint256 public exchangeRate;
+
+    event Deposit(uint256 wad);
+    event Withdraw(uint256 wad);
+    event Borrow(uint256 wad);
+    event Repay(uint256 wad);
+    event Liquidate(address guy, uint256 loanDaiAmt, uint256 depositEthAmt);
+
+    // @dev Deploy with address of Dai Stablecoin token
+    constructor(Dai _token, address _oracleAddress) {
+        token = _token;
+        owner = msg.sender;
+        priceFeed = AggregatorV3Interface(_oracleAddress);
+    }
+
+    //@notice Function used to get dai/eth exchange from price feed and convert eth to dai
+    //@param wad amount to apply exchange rate to
+    //@param update If true, will fetch exchange rate from oracle
+    function applyExchangeRate(uint256 _ethValue) internal view returns (uint256 _resultDai) {
+        (, int256 answer, , , ) = priceFeed.latestRoundData();
+        require(answer > 0, "Amount > 0 required");
+        uint256 _currentRate = uint256(answer);
+        _resultDai = _ethValue * _currentRate;
+        require(_resultDai / _currentRate == _ethValue, "Overflow");
+        return _resultDai;
+    }
+
+    //@notice Function used to deposit eth
+    function deposit() external payable {
+        require(msg.value > 0, "Amount > 0 required");
+        deposits[msg.sender] += msg.value;
+        emit Deposit(msg.value);
+    }
+
+    //@notice Function used to withdraw eth
+    function withdraw(uint256 _ethWad) external {
+        require(_ethWad > 0, "Amount > 0 required");
+        uint256 _deposit = deposits[msg.sender];
+        require(_deposit > 0, "Insufficient balance");
+        uint256 _depositDaiValue = applyExchangeRate(_deposit);
+        uint256 _withdrawDaiValue = applyExchangeRate(_ethWad);
+        require((_depositDaiValue - loans[msg.sender]) >= _withdrawDaiValue, "Insufficient balance");
+        deposits[msg.sender] -= _ethWad;
+        payable(msg.sender).transfer(_ethWad);
+        emit Withdraw(_ethWad);
+    }
+
+    //@notice Function used to borrow dai collateralized by eth deposit
+    function borrow(uint256 _daiWad) external {
+        require(_daiWad > 0, "Amount > 0 required");
+        uint256 _depositEthValue = deposits[msg.sender];
+        require(_depositEthValue > 0, "Insufficient collateral1");
+        uint256 _depositDaiValue = applyExchangeRate(_depositEthValue);
+
+        require((loans[msg.sender] + _daiWad) <= _depositDaiValue, "Insufficient collateral2");
+        loans[msg.sender] += _daiWad;
+        token.push(msg.sender, _daiWad);
+        emit Borrow(_daiWad);
+    }
+
+    //@notice Function used to pay down dai loans
+    function repay(uint256 _daiWad) external {
+        require(_daiWad > 0, "Amount > 0 required");
+        require(_daiWad <= loans[msg.sender], "Amount > loaned");
+        loans[msg.sender] -= _daiWad;
+        token.pull(msg.sender, _daiWad);
+        emit Repay(_daiWad);
+    }
+
+    //@notice Function used to liquidate
+    function liquidate(address guy) external {
+        uint256 _depositEth = deposits[guy];
+        require(_depositEth > 0, "No deposit");
+        uint256 _loanDai = loans[guy];
+        require(_loanDai > 0, "No loan");
+        uint256 _depositDaiValue = applyExchangeRate(_depositEth);
+        require(_loanDai > _depositDaiValue, "Loan safe");
+        delete loans[guy];
+        delete deposits[guy];
+        emit Liquidate(guy, _loanDai, _depositEth);
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -16,7 +16,7 @@ import { NetworkUserConfig } from "hardhat/types";
 
 dotenvConfig({ path: resolve(__dirname, "./.env") });
 
-const chainIds = {
+export const chainIds = {
   ganache: 1337,
   goerli: 5,
   hardhat: 31337,

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "commit": "git-cz",
     "compile": "hardhat compile",
     "coverage": "cross-env CODE_COVERAGE=true hardhat coverage --solcoverjs ./.solcover.js --temp artifacts --testfiles \"./test/**/*.ts\"",
-    "deploy": "hardhat deploy:TokenAndVault3",
+    "deploy": "hardhat deploy:TokenAndVault4WithOracle",
     "lint": "yarn run lint:sol && yarn run lint:ts && yarn run prettier:check",
     "lint:sol": "solhint --config ./.solhint.json --max-warnings 0 \"contracts/**/*.sol\"",
     "lint:ts": "eslint --config ./.eslintrc.yaml --ignore-path ./.eslintignore --ext .js,.ts .",
@@ -81,5 +81,8 @@
     "prettier:check": "prettier --check --config ./.prettierrc.yaml \"**/*.{js,json,md,sol,ts}\"",
     "test": "hardhat test",
     "typechain": "cross-env TS_NODE_TRANSPILE_ONLY=true hardhat typechain"
+  },
+  "dependencies": {
+    "@chainlink/contracts": "^0.2.1"
   }
 }

--- a/tasks/deployers/tokenandvault.ts
+++ b/tasks/deployers/tokenandvault.ts
@@ -1,15 +1,32 @@
 import { task } from "hardhat/config";
 import { TaskArguments } from "hardhat/types";
 
-import { TooliganToken, TooliganToken__factory, Vault3, Vault3__factory } from "../../typechain";
+import {
+  Dai,
+  Dai__factory,
+  Vault4,
+  Vault4__factory,
+  MockPriceFeedAggregator,
+  MockPriceFeedAggregator__factory,
+} from "../../typechain";
 
-task("deploy:TokenAndVault3").setAction(async function (taskArguments: TaskArguments, { ethers }) {
-  const tooliganTokenFactory: TooliganToken__factory = await ethers.getContractFactory("TooliganToken");
-  const tooliganToken: TooliganToken = <TooliganToken>await tooliganTokenFactory.deploy();
-  await tooliganToken.deployed();
-  console.log("TooliganToken deployed to: ", tooliganToken.address);
-  const vault3Factory: Vault3__factory = await ethers.getContractFactory("Vault3");
-  const vault: Vault3 = <Vault3>await vault3Factory.deploy(tooliganToken.address, 1);
+task("deploy:TokenAndVault4WithOracle").setAction(async function (taskArguments: TaskArguments, { ethers }) {
+  const mockPriceFeedAggregatorFactory: MockPriceFeedAggregator__factory = await ethers.getContractFactory(
+    "MockPriceFeedAggregator",
+  );
+  const mockPriceFeedAggregator: MockPriceFeedAggregator = <MockPriceFeedAggregator>(
+    await mockPriceFeedAggregatorFactory.deploy(1)
+  );
+  await mockPriceFeedAggregator.deployed();
+  console.log("MockPriceFeedAggregator deployed to: ", mockPriceFeedAggregator.address);
+
+  const daiFactory: Dai__factory = await ethers.getContractFactory("Dai");
+  const { chainId } = await ethers.provider.getNetwork();
+  const dai: Dai = <Dai>await daiFactory.deploy(chainId);
+  await dai.deployed();
+  console.log("Dai deployed to: ", dai.address);
+  const vault4Factory: Vault4__factory = await ethers.getContractFactory("Vault4");
+  const vault: Vault4 = <Vault4>await vault4Factory.deploy(dai.address, mockPriceFeedAggregator.address);
   await vault.deployed();
   console.log("Vault deployed to: ", vault.address);
 });

--- a/test/token/Dai.ts
+++ b/test/token/Dai.ts
@@ -1,0 +1,24 @@
+import hre from "hardhat";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { expect } from "chai";
+import { Dai } from "../../typechain";
+
+const { deployContract } = hre.waffle;
+
+describe("Dai", function () {
+  this.timeout(0);
+
+  before(async function () {
+    const signers: SignerWithAddress[] = await hre.ethers.getSigners();
+    this.token = <Dai>await deployContract(signers[0], await hre.artifacts.readArtifact("Dai"));
+    this.admin = signers[0];
+    this.user1 = signers[1];
+  });
+
+  it("should mint", async function () {
+    const mintAmount = 100;
+    await expect(this.token.connect(this.admin).mint(this.user1.address, mintAmount)).to.not.be.reverted;
+
+    expect(await this.token.connect(this.admin).balanceOf(this.user1.address)).to.equal(mintAmount);
+  });
+});

--- a/test/vault/Vault4.ts
+++ b/test/vault/Vault4.ts
@@ -1,0 +1,199 @@
+import hre, { network } from "hardhat";
+import { BigNumber } from "ethers";
+
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import { Signers } from "../types";
+import { expect } from "chai";
+import { Dai, Vault4, MockPriceFeedAggregator } from "../../typechain";
+
+const { deployContract } = hre.waffle;
+const { parseEther } = hre.ethers.utils;
+describe("Vault4 Unit tests", function () {
+  this.timeout(0);
+
+  let user1: SignerWithAddress; // assigned to this.signers[1]
+  let user2: SignerWithAddress; // assigned to this.signers[2]
+
+  const WAD = BigNumber.from("1" + "0".repeat(18));
+  const initialExchangeRate = 3955;
+
+  const vaultStartingDai = WAD.mul(200000);
+  const user1StartingEth = parseEther("10");
+  const user2StartingEth = parseEther("5");
+
+  const depositEth1 = parseEther("1.5");
+  const depositEth2 = parseEther("3");
+  const borrowDai1 = depositEth1.mul(initialExchangeRate);
+  const borrowDai2 = depositEth2.mul(initialExchangeRate).div(2);
+
+  before(async function () {
+    const signers: SignerWithAddress[] = await hre.ethers.getSigners();
+    this.signers = {
+      admin: signers[0],
+      user1: signers[1],
+      user2: signers[2],
+    } as Signers;
+    user1 = this.signers.user1;
+    user2 = this.signers.user2;
+  });
+
+  beforeEach(async function () {
+    this.dai = <Dai>await deployContract(this.signers.admin, await hre.artifacts.readArtifact("Dai"), [1]);
+    this.mockPriceFeedAggregator = <MockPriceFeedAggregator>(
+      await deployContract(this.signers.admin, await hre.artifacts.readArtifact("MockPriceFeedAggregator"), [
+        initialExchangeRate,
+      ])
+    );
+    this.vault = <Vault4>(
+      await deployContract(this.signers.admin, await hre.artifacts.readArtifact("Vault4"), [
+        this.dai.address,
+        this.mockPriceFeedAggregator.address,
+      ])
+    );
+    // Fund the vault with some dai
+    await this.dai.mint(this.vault.address, vaultStartingDai);
+
+    // Fund 2 users with some eth
+    await network.provider.send("hardhat_setBalance", [user1.address, user1StartingEth.toHexString()]);
+    await network.provider.send("hardhat_setBalance", [user2.address, user2StartingEth.toHexString()]);
+  });
+  describe("without deposits or loans", function () {
+    it("#withdraw() should not be able to withdraw without a deposit", async function () {
+      await expect(this.vault.connect(user1).withdraw(1)).to.be.revertedWith("Insufficient balance");
+    });
+
+    it("#borrow() should not be able to borrow without a deposit", async function () {
+      await expect(this.vault.connect(user1).borrow(1000)).to.be.revertedWith("Insufficient collateral");
+    });
+
+    it("#liquidate() should not be able to liquidate without a deposit", async function () {
+      await expect(this.vault.connect(this.signers.admin).liquidate(user1.address)).to.be.revertedWith("No deposit");
+    });
+
+    it("#deposit() should allow deposits from one or more users", async function () {
+      await expect(this.vault.connect(user1).deposit({ value: depositEth1 }))
+        .to.emit(this.vault, "Deposit")
+        .withArgs(depositEth1);
+      expect(await this.vault.deposits(user1.address)).to.be.equal(depositEth1);
+      await this.vault.connect(user2).deposit({ value: depositEth2 });
+      expect(await this.vault.deposits(user2.address)).to.be.equal(depositEth2);
+    });
+  });
+
+  describe("with deposits", function () {
+    beforeEach(async function () {
+      await this.vault.connect(user1).deposit({ value: depositEth1 });
+      await this.vault.connect(user2).deposit({ value: depositEth2 });
+    });
+
+    it("#withdraw() should not be able to withdraw more than the deposit", async function () {
+      await expect(this.vault.connect(user1).withdraw(depositEth1.add(parseEther("0.5")))).to.be.revertedWith(
+        "Insufficient balance",
+      );
+    });
+
+    it("#borrow() should not be able to borrow more than the deposit", async function () {
+      const borrow = depositEth1.add(parseEther("0.5")).mul(initialExchangeRate);
+      await expect(this.vault.connect(user1).borrow(borrow)).to.be.revertedWith("Insufficient collateral");
+    });
+
+    it("#deposit() should allow additional deposits", async function () {
+      await this.vault.connect(user1).deposit({ value: depositEth2 });
+      expect(await this.vault.deposits(user1.address)).to.be.equal(depositEth1.add(depositEth2));
+    });
+
+    it("#withdraw() should be able to withdraw up to the deposited amount", async function () {
+      // User1 withdraws entire deposit
+      await expect(this.vault.connect(user1).withdraw(depositEth1))
+        .to.emit(this.vault, "Withdraw")
+        .withArgs(depositEth1);
+      expect(await this.vault.deposits(user1.address)).to.be.equal(0);
+      // User2 withdraws leaving 0.5 eth in the account
+      await this.vault.connect(user2).withdraw(depositEth2.sub(parseEther("0.5")));
+      expect(await this.vault.deposits(user2.address)).to.be.equal(parseEther("0.5"));
+    });
+
+    it("#borrow() should be able to borrow up to the deposited amount at current exchange rate", async function () {
+      // User1 borrows entire deposit
+      await expect(this.vault.connect(user1).borrow(borrowDai1)).to.emit(this.vault, "Borrow").withArgs(borrowDai1);
+      expect(await this.vault.deposits(user1.address)).to.be.equal(depositEth1);
+      expect(await this.vault.loans(user1.address)).to.be.equal(borrowDai1);
+      expect(await this.dai.balanceOf(user1.address)).to.be.equal(borrowDai1);
+
+      // // User2 borrows half of deposit worth
+      await this.vault.connect(user2).borrow(borrowDai2);
+      expect(await this.vault.deposits(user2.address)).to.be.equal(depositEth2);
+      expect(await this.vault.loans(user2.address)).to.be.equal(borrowDai2);
+      expect(await this.dai.balanceOf(user2.address)).to.be.equal(borrowDai2);
+    });
+
+    describe("with loans", function () {
+      beforeEach(async function () {
+        // User1 borrows entire deposit
+        await this.vault.connect(user1).borrow(borrowDai1);
+        // User2 borrows half of deposit worth
+        await this.vault.connect(user2).borrow(borrowDai2);
+      });
+
+      it("#withdraw() should not be able to withdraw deposits being used as collateral", async function () {
+        await expect(this.vault.connect(user1).withdraw(depositEth1)).to.be.revertedWith("Insufficient balance");
+      });
+
+      it("#borrow() should not be able to borrow beyond available collateral", async function () {
+        await expect(this.vault.connect(user1).borrow(1000)).to.be.revertedWith("Insufficient collateral");
+        await expect(this.vault.connect(user2).borrow(borrowDai2)).to.not.be.reverted;
+        await expect(this.vault.connect(user2).borrow(1000)).to.be.revertedWith("Insufficient collateral");
+      });
+
+      it("#liquidate() should not be able to liquidate safe loans", async function () {
+        await expect(this.vault.connect(this.signers.admin).liquidate(user1.address)).to.be.revertedWith("Loan safe");
+        await expect(this.vault.connect(this.signers.admin).liquidate(user2.address)).to.be.revertedWith("Loan safe");
+      });
+
+      it("#repay() should not be able to repay more than the borrowed amount", async function () {
+        await this.dai.connect(this.signers.user1).approve(this.vault.address, borrowDai1.mul(2));
+        await expect(this.vault.connect(user1).repay(borrowDai1.mul(2))).to.be.revertedWith("Amount > loaned");
+      });
+
+      it("#repay() should be able to repay up to the borrowed amount", async function () {
+        await this.dai.connect(this.signers.user1).approve(this.vault.address, borrowDai1);
+        await expect(this.vault.connect(user1).repay(borrowDai1)).to.emit(this.vault, "Repay").withArgs(borrowDai1);
+        expect(await this.vault.deposits(user1.address)).to.be.equal(depositEth1);
+        expect(await this.vault.loans(user1.address)).to.be.equal(0);
+
+        const repayDai = borrowDai1.div(2);
+        await this.dai.connect(this.signers.user2).approve(this.vault.address, repayDai);
+        await this.vault.connect(user2).repay(repayDai);
+        expect(await this.vault.deposits(user2.address)).to.be.equal(depositEth2);
+        expect(await this.vault.loans(user2.address)).to.be.equal(repayDai);
+      });
+
+      it("#liquidate() should be able to liquidate underwater loans", async function () {
+        await this.mockPriceFeedAggregator.setRate(50); // Setting eth/dai rate to $50
+        await expect(this.vault.connect(this.signers.admin).liquidate(user1.address))
+          .to.emit(this.vault, "Liquidate")
+          .withArgs(user1.address, borrowDai1, depositEth1);
+        await expect(this.vault.connect(this.signers.admin).liquidate(user2.address))
+          .to.emit(this.vault, "Liquidate")
+          .withArgs(user2.address, borrowDai2, depositEth2);
+        expect(await this.vault.deposits(user1.address)).to.be.equal(0);
+        expect(await this.vault.loans(user1.address)).to.be.equal(0);
+        expect(await this.vault.deposits(user2.address)).to.be.equal(0);
+        expect(await this.vault.loans(user2.address)).to.be.equal(0);
+        expect(await hre.ethers.provider.getBalance(this.vault.address)).to.be.equal(depositEth1.add(depositEth2));
+      });
+
+      it("#withdraw() should be able to withdraw additional eth if ltv drops", async function () {
+        await expect(this.vault.connect(user1).withdraw(parseEther("1"))).to.be.revertedWith("Insufficient balance");
+        await this.mockPriceFeedAggregator.setRate(20000); // Setting eth/dai rate to $20,000
+        await expect(this.vault.connect(user1).withdraw(parseEther("1"))).to.be.not.be.reverted;
+      });
+
+      it("#borrow() should be able to borrow additional eth if ltv drops", async function () {
+        await expect(this.vault.connect(user1).borrow(1000)).to.be.revertedWith("Insufficient collateral");
+        await this.mockPriceFeedAggregator.setRate(20000); // Setting eth/dai rate to $20,000
+        await expect(this.vault.connect(user1).borrow(1000)).to.be.not.be.reverted;
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,6 +41,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@chainlink/contracts@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "@chainlink/contracts@npm:0.2.1"
+  checksum: fdc5e4354f736f4743f229f979a0c4cc546bba00e71dc00c5e2c928f0c3ec5a03d27e104bc604189aa15d4ff55bfec63e97ce38cf6ab35c51499d75c6843d2ea
+  languageName: node
+  linkType: hard
+
 "@codechecks/client@npm:^0.1.11":
   version: 0.1.11
   resolution: "@codechecks/client@npm:0.1.11"
@@ -1194,6 +1201,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@paulrberg/solidity-template@workspace:."
   dependencies:
+    "@chainlink/contracts": ^0.2.1
     "@codechecks/client": ^0.1.11
     "@commitlint/cli": ^13.1.0
     "@commitlint/config-conventional": ^13.1.0


### PR DESCRIPTION
[Exercise5: Collateralized Vault](https://github.com/alcueca/solidity-mentorship/issues/5)
A vault which accepts eth deposits and can lend dai.  Includes "liquidate" function as well as using a mock price feed aggregator based on Chainlink.

I deployed the contracts to Kovan but ran into problems verifying -- just hangs here forever.  I haven't had this problem on any of the othe exercises:

```
$ yarn hardhat verify --network kovan 0x3F628796dBA8269E484d34Bd4a07c967b786069A 0x5f25FEF2a2Fb696c4e24ac6a5147D2b454A1f5f6 0x8428d2B425B7A0D008B2576d39d72971c2d5aC1c
Nothing to compile
No need to generate any newer typings.
Compiling 1 file with 0.8.6
Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
--> contracts/Dai.sol


Successfully submitted source code for contract
contracts/Vault4.sol:Vault4 at 0x3F628796dBA8269E484d34Bd4a07c967b786069A
for verification on Etherscan. Waiting for verification result...
```

Tests complete:
```
  Vault4 Unit tests
    without deposits or loans
      ✓ #withdraw() should not be able to withdraw without a deposit
      ✓ #borrow() should not be able to borrow without a deposit
      ✓ #liquidate() should not be able to liquidate without a deposit
      ✓ #deposit() should allow deposits from one or more users (64ms)
    with deposits
      ✓ #withdraw() should not be able to withdraw more than the deposit
      ✓ #borrow() should not be able to borrow more than the deposit
      ✓ #deposit() should allow additional deposits
      ✓ #withdraw() should be able to withdraw up to the deposited amount (222ms)
      ✓ #borrow() should be able to borrow up to the deposited amount at current exchange rate (77ms)
      with loans
        ✓ #withdraw() should not be able to withdraw deposits being used as collateral
        ✓ #borrow() should not be able to borrow beyond available collateral (39ms)
        ✓ #liquidate() should not be able to liquidate safe loans
        ✓ #repay() should not be able to repay more than the borrowed amount
        ✓ #repay() should be able to repay up to the borrowed amount (179ms)
        ✓ #liquidate() should be able to liquidate underwater loans (126ms)
        ✓ #withdraw() should be able to withdraw additional eth if ltv drops (93ms)
        ✓ #borrow() should be able to borrow additional eth if ltv drops (41ms)


  17 passing (3s)
```

